### PR TITLE
Fix build failures in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
             echo 'builder ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/builder
             chmod 440 /etc/sudoers.d/builder
             chown -R builder:builder /workspace
-            sudo -u builder bash -c 'cd $pkg && makepkg --noconfirm --needed'
+            sudo -u builder bash -c \"cd '$pkg' && makepkg --noconfirm --needed\"
           "
 
       # Extract package info for artifacts and releases
@@ -154,7 +154,7 @@ jobs:
           if [[ -n "${{ steps.makepkg_standard.outputs.pkgfile0 }}" ]]; then
             PKGFILE="${{ steps.makepkg_standard.outputs.pkgfile0 }}"
           else
-            PKGFILE=$(find . -maxdepth 1 -name "*.pkg.tar.zst" | head -1)
+            PKGFILE=$(find . -maxdepth 1 -name "*.pkg.tar.zst" | head -1 | sed 's|^\./||')
             [[ -z "$PKGFILE" ]] && PKGFILE="${PKGNAME}-${PKGVER}-${PKGREL}-x86_64.pkg.tar.zst"
           fi
 

--- a/obs-studio/PKGBUILD
+++ b/obs-studio/PKGBUILD
@@ -18,8 +18,7 @@ source=(
   "https://patch-diff.githubusercontent.com/raw/obsproject/obs-studio/pull/12328.patch"
 )
 sha256sums=('SKIP'
-  '48d744037c553eea8f9b76bf46f6dcac753e52871f49b2c1a2580757f723a1b7'
-  '25322c692cf5cc88fc7d17cbb40a61b7e32d5ea675da647dd1a1996474ec2c8e')
+  '48d744037c553eea8f9b76bf46f6dcac753e52871f49b2c1a2580757f723a1b7')
 prepare() {
   cd "${pkgname}-${pkgver}-sources"
   patch -Np1 -i "${srcdir}/12328.patch" || :


### PR DESCRIPTION
This commit addresses three critical build failures:

1. Fix egl-wayland2 artifact upload error: Strip './' prefix from package filenames found by find command to prevent "Invalid pattern" errors in actions/upload-artifact when paths contain relative pathing.

2. Fix Docker build variable expansion: Change quoting in docker build command to properly expand $pkg variable by using escaped double quotes instead of single quotes, allowing the package directory to be correctly referenced during makepkg execution.

3. Fix obs-studio PKGBUILD checksum mismatch: Remove extraneous sha256sum entry - package has 2 sources but had 3 checksums defined.

Fixes: https://github.com/Ven0m0/PKG/actions/runs/19588595922