### PR TITLE
Integrate Firefox Vanilla optimizations into firefox/ build

### DIFF
--- a/firefox/BUILD-NOTES.md
+++ b/firefox/BUILD-NOTES.md
@@ -10,6 +10,9 @@ This is an ultimate optimized Firefox PKGBUILD merged from multiple variants, fe
 - **Optional LLVM BOLT**: Post-link binary optimization (requires llvm-bolt)
 - **Smart core limiting**: Automatically limits parallel builds based on available RAM
 - **sccache support**: Auto-detected for faster compilation
+- **Enhanced WASM optimizations**: Memory64, multi-memory, branch hinting, relaxed SIMD
+- **Aggressive optimization flags**: Disabled security hardening features (PHC, DMD) for maximum performance
+- **Rust optimizations**: Target-cpu=native, LTO, zero debug info, no frame pointers
 
 ### Hardware Acceleration
 - **VA-API**: Hardware video decoding (force-enabled)
@@ -20,8 +23,9 @@ This is an ultimate optimized Firefox PKGBUILD merged from multiple variants, fe
 ### System Integration
 - **System libraries**: Uses system nspr, nss, vpx, webp, icu, av1, harfbuzz, graphite
 - **Wayland native**: Full Wayland support
-- **WASM optimizations**: SIMD/AVX support enabled
+- **WASM optimizations**: SIMD/AVX/Memory64/Multi-memory/Branch hinting/Relaxed SIMD enabled
 - **KDE integration**: Patches included for better KDE desktop integration
+- **Image format support**: JXL (JPEG XL), RAW, AV1 image formats enabled
 
 ### Privacy & Enhancements
 - **Telemetry disabled**: All tracking and telemetry disabled by default
@@ -207,6 +211,23 @@ ENABLE_PGO_REUSE=true makepkg -si
 | Telemetry | Enabled | Disabled |
 | KDE integration | ✗ | ✓ |
 
+## Optimizations from Firefox Vanilla
+
+This build now incorporates advanced optimizations from the [Firefox Vanilla](https://github.com/Ven0m0/firefox-vanilla) project:
+
+- **Enhanced WASM support**: Added memory64, multi-memory, branch hinting, and relaxed SIMD features
+- **Aggressive module disabling**: Disabled PHC (Probabilistic Heap Checker), DMD (Dark Matter Detector), and Valgrind integration
+- **Property minification**: JavaScript property minification for smaller binaries
+- **RAW image support**: Native support for RAW image formats
+- **Optimized Rust compilation**: Enhanced RUSTFLAGS with debuginfo=0 and no frame pointers
+
+These optimizations are based on Firefox Vanilla's ESR 140 branch, which showed benchmark improvements of:
+- Octane 2.0: +0.38%
+- Speedometer 2.1: +2.00%
+- Speedometer 3.0: +2.17%
+- JetStream 3.0: +3.81%
+- MotionMark 1.3.1: +15.50%
+
 ## Credits
 
 This PKGBUILD is merged from:
@@ -215,6 +236,7 @@ This PKGBUILD is merged from:
 - firefox-kde-opensuse (KDE integration, system libs)
 - Floorp PKGBUILD (PGO reuse, smart core limiting)
 - Flowfox and Waterfox PKGBUILDs
+- [Firefox Vanilla](https://github.com/Ven0m0/firefox-vanilla) (Advanced optimizations, WASM enhancements)
 
 ## License
 

--- a/firefox/PKGBUILD
+++ b/firefox/PKGBUILD
@@ -79,6 +79,7 @@ _rustflags=(
   -Ctarget-cpu=native -Copt-level=3
   -Ccodegen-units=1 -Clto=fat -Cpanic=abort
   -Clink-arg=-fuse-ld=lld -Cllvm-args=-enable-dfa-jump-thread
+  -Cdebuginfo=0 -Cforce-frame-pointers=no
 )
 
 prepare() {
@@ -133,6 +134,11 @@ ac_add_options --enable-optimize="-O3 -march=native -mtune=native"
 ac_add_options --enable-rust-simd
 ac_add_options --enable-wasm-simd
 ac_add_options --enable-wasm-avx
+ac_add_options --enable-wasm-relaxed-simd
+ac_add_options --enable-wasm-memory64
+ac_add_options --enable-wasm-memory-control
+ac_add_options --enable-wasm-multi-memory
+ac_add_options --enable-wasm-branch-hinting
 ac_add_options --enable-linker=lld
 ac_add_options --enable-lto=full
 ac_add_options --disable-elf-hack
@@ -149,6 +155,7 @@ ac_add_options --enable-jemalloc
 # Stripping
 ac_add_options --enable-strip
 ac_add_options --enable-install-strip
+ac_add_options --enable-minify=properties
 export STRIP_FLAGS="--strip-debug --strip-unneeded"
 # Disable debug features
 ac_add_options --disable-tests
@@ -159,6 +166,9 @@ ac_add_options --disable-crashreporter
 ac_add_options --disable-updater
 ac_add_options --disable-default-browser-agent
 ac_add_options --disable-parental-controls
+ac_add_options --disable-phc
+ac_add_options --disable-dmd
+ac_add_options --disable-valgrind
 # Wayland support
 ac_add_options --enable-default-toolkit=cairo-gtk3-wayland
 ac_add_options --enable-wayland
@@ -180,6 +190,7 @@ ac_add_options --with-system-jpeg
 # Media features
 ac_add_options --enable-jxl
 ac_add_options --enable-av1
+ac_add_options --enable-raw
 ac_add_options --enable-pulseaudio
 ac_add_options --enable-alsa
 ac_add_options --enable-jack

--- a/firefox/mozconfig
+++ b/firefox/mozconfig
@@ -6,15 +6,23 @@ ac_add_options --enable-optimize=-O3
 ac_add_options --enable-lto=full
 ac_add_options --enable-lto
 ac_add_options --enable-clang-plugin
+ac_add_options --enable-minify=properties
 ac_add_options --enable-hardening
 ac_add_options --enable-replace-malloc
 ac_add_options --enable-webrtc
 ac_add_options --enable-jxl
 ac_add_options --enable-av1
+ac_add_options --enable-raw
 ac_add_options --enable-wayland
 ac_add_options --enable-jemalloc
 ac_add_options --enable-wasm-avx
 ac_add_options --enable-rust-simd
+ac_add_options --enable-wasm-simd
+ac_add_options --enable-wasm-relaxed-simd
+ac_add_options --enable-wasm-memory64
+ac_add_options --enable-wasm-memory-control
+ac_add_options --enable-wasm-multi-memory
+ac_add_options --enable-wasm-branch-hinting
 ac_add_options --enable-pulseaudio
 ac_add_options --enable-alsa
 ac_add_options --enable-jack
@@ -56,6 +64,10 @@ ac_add_options --disable-webspeech
 ac_add_options --disable-webspeechtestbackend
 ac_add_options --disable-default-browser-agent
 ac_add_options --disable-warnings-as-errors
+ac_add_options --disable-valgrind
+ac_add_options --disable-dmd
+ac_add_options --disable-phc
+ac_add_options --disable-bits-download
 
 # Parallel build
 mk_add_options AUTOCLOBBER=1
@@ -78,7 +90,12 @@ export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,-O3 -Wl,--gc-sections -Wl,-z,now -Wl,-z,relro -Wl,--icf=all -Wl,--as-needed -Wl,--hash-style=gnu -Wl,--sort-common -Wl,--build-id=none"
 
 export RUSTC_OPT_LEVEL=3
+export OPT_LEVEL=3
 export MOZ_NO_PIE_COMPAT=1 MOZ_NOSPAM=1 MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=system
+
+# Optimization levels for mozconfig
+ac_add_options OPT_LEVEL="3"
+ac_add_options RUSTC_OPT_LEVEL="3"
 
 if [ -n "$PGO_PROFILE_USE" ]; then
   export MOZ_LTO=cross,full

--- a/firefox/readme.md
+++ b/firefox/readme.md
@@ -25,8 +25,10 @@ ENABLE_BOLT=true makepkg -si
 ✅ **System library integration** (reduces size, improves compatibility)
 ✅ **Privacy-focused** (all telemetry disabled)
 ✅ **KDE integration patches** included
-✅ **WASM SIMD/AVX** optimizations enabled
+✅ **WASM SIMD/AVX/Memory64** optimizations enabled
 ✅ **sccache support** (auto-detected)
+✅ **Firefox Vanilla optimizations** (Enhanced WASM, aggressive module disabling)
+✅ **RAW image format support** enabled
 
 ## Build Options
 
@@ -81,6 +83,7 @@ This ultimate PKGBUILD is merged from multiple optimized Firefox builds:
 - **Floorp PKGBUILD** - PGO profile reuse, smart core limiting
 - **Flowfox** - Clean build patterns
 - **Waterfox** - Additional optimization techniques
+- **[Firefox Vanilla](https://github.com/Ven0m0/firefox-vanilla)** - Enhanced WASM optimizations, aggressive performance tuning
 
 ### Additional Credits
 - https://build.opensuse.org/package/show/mozilla:Factory/MozillaFirefox
@@ -112,7 +115,7 @@ CFLAGS="-O3 -march=native -mtune=native -fomit-frame-pointer -ffunction-sections
 LDFLAGS="-Wl,-O3 -Wl,--gc-sections -Wl,--sort-common -Wl,--as-needed -Wl,-z,pack-relative-relocs -Wl,-z,relro -Wl,-z,now -flto -fuse-linker-plugin"
 
 # Rust flags
-RUSTFLAGS="-Ctarget-cpu=native -Copt-level=3 -Clto=fat -Ccodegen-units=1 -Cpanic=abort -Clink-arg=-fuse-ld=lld -Cllvm-args=-enable-dfa-jump-thread"
+RUSTFLAGS="-Ctarget-cpu=native -Copt-level=3 -Clto=fat -Ccodegen-units=1 -Cpanic=abort -Clink-arg=-fuse-ld=lld -Cllvm-args=-enable-dfa-jump-thread -Cdebuginfo=0 -Cforce-frame-pointers=no"
 
 # Polly (optional)
 -mllvm -polly -mllvm -polly-vectorizer=stripmine


### PR DESCRIPTION
Incorporated advanced optimizations from Firefox Vanilla (esr140 branch) to enhance performance:

**Enhanced WASM Optimizations:**
- Added --enable-wasm-memory64 for 64-bit memory support
- Added --enable-wasm-memory-control for fine-grained memory control
- Added --enable-wasm-multi-memory for multiple memory instances
- Added --enable-wasm-branch-hinting for better branch prediction
- Added --enable-wasm-relaxed-simd for additional SIMD operations

**Aggressive Performance Tuning:**
- Disabled PHC (Probabilistic Heap Checker) for reduced overhead
- Disabled DMD (Dark Matter Detector) - not needed in release builds
- Disabled Valgrind integration
- Disabled bits-download feature
- Added --enable-minify=properties for smaller binaries

**Additional Features:**
- Added RAW image format support (--enable-raw)
- Enhanced Rust compilation flags (debuginfo=0, no frame pointers)
- Explicit OPT_LEVEL and RUSTC_OPT_LEVEL settings

**Documentation Updates:**
- Updated BUILD-NOTES.md with Firefox Vanilla integration details
- Added benchmark performance metrics from Firefox Vanilla
- Updated readme.md to reflect new optimizations
- Added Firefox Vanilla to credits and sources

Based on Firefox Vanilla ESR 140 branch optimizations which demonstrated:
- Octane 2.0: +0.38% improvement
- Speedometer 2.1: +2.00% improvement
- Speedometer 3.0: +2.17% improvement
- JetStream 3.0: +3.81% improvement
- MotionMark 1.3.1: +15.50% improvement

Source: https://github.com/Ven0m0/firefox-vanilla/tree/esr140