### PR TITLE
Lint and format PKGBUILDs and shell scripts

### DIFF
--- a/7zip/PKGBUILD
+++ b/7zip/PKGBUILD
@@ -25,19 +25,19 @@ sha256sums=('b2fa9db70232661ff962bab631ff88e56a894caf0c15fae5070135f18408d5b9'
             '4db7e3a938675b97a9a3440b9c7127d8a990390df2dfe0da7dcabe654abb3579')
 
 prepare() {
-  cd $_pkgname-$pkgver.$_upstream_pkgrel
+  cd "$_pkgname-$pkgver.$_upstream_pkgrel"
 
   # Prepare binary directory
   mkdir -p bin
 }
 
 build() {
-  cd $_pkgname-$pkgver.$_upstream_pkgrel
+  cd "$_pkgname-$pkgver.$_upstream_pkgrel"
   cp -a "$srcdir/p7zip" bin/
 }
 
 package() {
-  cd $_pkgname-$pkgver.$_upstream_pkgrel
+  cd "$_pkgname-$pkgver.$_upstream_pkgrel"
 
   make install \
     DEST_DIR="$pkgdir" \

--- a/heroic-games-launcher/PKGBUILD
+++ b/heroic-games-launcher/PKGBUILD
@@ -17,17 +17,17 @@ source=(git+https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git)
 sha256sums=('SKIP')
 
 pkgver() {
-  cd $_pkgname
+  cd "$_pkgname"
   git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {
-  cd $_pkgname
+  cd "$_pkgname"
   sed -i -e "s/Exec=heroic-run /Exec=heroic /" "flatpak/com.heroicgameslauncher.hgl.desktop"
 }
 
 build() {
-  cd $_pkgname
+  cd "$_pkgname"
   pnpm install
   pnpm run download-helper-binaries
   pnpm dist:linux --x64 --dir -c.electronDist=/usr/lib/$_electron/ -c.electronVersion=$(cat /usr/lib/$_electron/version)

--- a/qpdf/.SRCINFO
+++ b/qpdf/.SRCINFO
@@ -1,0 +1,21 @@
+pkgbase = qpdf-zopfli
+	pkgdesc = QPDF: A Content-Preserving PDF Transformation System (with Zopfli support)
+	pkgver = 12.2.0
+	pkgrel = 1
+	url = https://github.com/qpdf/qpdf
+	arch = x86_64
+	license = Apache-2.0
+	license = Artistic-2.0
+	makedepends = cmake
+	depends = gcc-libs
+	depends = glibc
+	depends = libjpeg-turbo
+	depends = openssl
+	depends = zlib
+	depends = zopfli
+	provides = qpdf
+	conflicts = qpdf
+	source = https://github.com/qpdf/qpdf/releases/download/v12.2.0/qpdf-12.2.0.tar.gz
+	sha256sums = b3d1575b2218badc3549d6977524bb0f8c468c6528eebc8967bbe3078cf2cace
+
+pkgname = qpdf-zopfli

--- a/qpdf/PKGBUILD
+++ b/qpdf/PKGBUILD
@@ -20,7 +20,7 @@ source=("https://github.com/qpdf/qpdf/releases/download/v$pkgver/${_pkgname}-${p
 sha256sums=('b3d1575b2218badc3549d6977524bb0f8c468c6528eebc8967bbe3078cf2cace')
 
 build() {
-  cd ${_pkgname}-${pkgver}
+  cd "${_pkgname}-${pkgver}"
   cmake -B build \
     -DCMAKE_INSTALL_PREFIX:PATH=/usr \
     -D BUILD_STATIC_LIBS:BOOL=OFF \
@@ -34,12 +34,12 @@ build() {
 }
 
 check() {
-  cd ${_pkgname}-${pkgver}
+  cd "${_pkgname}-${pkgver}"
   make -C build test
 }
 
 package() {
-  cd ${_pkgname}-${pkgver}
+  cd "${_pkgname}-${pkgver}"
   make -C build DESTDIR="${pkgdir}" install
   install -Dm644 completions/bash/qpdf "${pkgdir}/usr/share/bash-completion/completions/qpdf"
   install -Dm644 completions/zsh/_qpdf "${pkgdir}/usr/share/zsh/site-functions/_qpdf"

--- a/watchman/PKGBUILD
+++ b/watchman/PKGBUILD
@@ -56,7 +56,7 @@ sha256sums=('088be97d0e3e14874b23436e3eb9ecf9a1df47453a988c7cd8a3b3aa099589bd'
             '853457ad70492fec9d7d020b9e067e2aec2ca419c0a5cddd5d93c5fab354c87a')
 
 prepare() {
-  cd ${pkgname}-${pkgver}
+  cd "${pkgname}-${pkgver}"
   patch -Np1 --ignore-whitespace --fuzz=3 -i ../watchman-destdir.patch
   # Use system CMake config instead of bundled module, incompatible with glog
   sed -i 's/find_package(Glog REQUIRED)/find_package(Glog CONFIG REQUIRED)/' \
@@ -79,7 +79,7 @@ END
 }
 
 build() {
-  cd ${pkgname}-${pkgver}
+  cd "${pkgname}-${pkgver}"
   export RUSTUP_TOOLCHAIN=stable
   cmake -S . -B build \
     -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr \
@@ -91,12 +91,12 @@ build() {
 }
 
 check() {
-  cd ${pkgname}-${pkgver}
+  cd "${pkgname}-${pkgver}"
   ctest --test-dir build --output-on-failure --exclude-regex "[Bb]ig|[Ii]ntegration"
 }
 
 package() {
-  cd $pkgname-$pkgver
+  cd "$pkgname-$pkgver"
   DESTDIR="$pkgdir" cmake --install build
   install -Dm644 /dev/stdin "$pkgdir/usr/lib/tmpfiles.d/watchman.conf" <<END
 d /run/watchman 1777 root root

--- a/webp-converter/webp-converter.sh
+++ b/webp-converter/webp-converter.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -o pipefail
+set -euo pipefail
+IFS=$'\n\t'
 _APPDIR="/usr/lib/@appname@"
 _RUNNAME="${_APPDIR}/@runname@"
 _CFGDIR="@cfgdirname@/"


### PR DESCRIPTION
- Fixed unquoted variable expansions in cd commands across multiple PKGBUILDs
- Added proper quoting to prevent word splitting issues in: qpdf, watchman, 7zip, heroic-games-launcher
- Enhanced shell script safety in webp-converter.sh by adding full set -euo pipefail and IFS settings
- Generated missing .SRCINFO for qpdf package
- All changes follow CLAUDE.md coding standards and EditorConfig settings