### PR TITLE
Add sccache and clang/lld support to C/C++ builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,8 @@ jobs:
       - name: Setup sccache
         if: steps.build_method.outputs.method == 'standard'
         uses: mozilla-actions/sccache-action@v0.0.9
+        with:
+          version: "v0.9.0"
       - name: Cache Rust artifacts
         if: steps.build_method.outputs.method == 'standard'
         uses: actions/cache@v4
@@ -151,7 +153,11 @@ jobs:
         env:
           CC: clang
           CXX: clang++
+          AR: llvm-ar
+          NM: llvm-nm
+          RANLIB: llvm-ranlib
           RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
       - name: Set up Docker Buildx
         if: steps.build_method.outputs.method == 'docker'
         uses: docker/setup-buildx-action@v3

--- a/chromium/PKGBUILD
+++ b/chromium/PKGBUILD
@@ -198,6 +198,11 @@ build() {
   cd chromium-$_pkgver
   if ((_system_clang)); then
     export CC=clang CXX=clang++ AR=ar NM=nm
+    # Use sccache if available for faster compilation
+    if command -v sccache &>/dev/null; then
+      export CC="sccache clang"
+      export CXX="sccache clang++"
+    fi
   else
     local _clang_path="$PWD/third_party/llvm-build/Release+Asserts/bin"
     export CC=$_clang_path/clang CXX=$_clang_path/clang++ AR=$_clang_path/llvm-ar NM=$_clang_path/llvm-nm

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url='https://curl.se/'
 license=('MIT')
 options=('strip')
-makedepends=('openssl' 'rustls' 'wolfssl' 'pkg-config' 'autoconf' 'automake' 'libtool' 'quiche')
+makedepends=('openssl' 'rustls' 'wolfssl' 'pkg-config' 'autoconf' 'automake' 'libtool' 'quiche' 'clang' 'lld')
 source=("https://curl.se/download/curl-${pkgver}.tar.xz")
 sha256sums=('db59cf0d671ca6e7f5c2c5ec177084a33a79e04c97e71cf183a5cdea235054eb')
 
@@ -18,8 +18,18 @@ prepare() {
 
 build() {
   cd "curl-$pkgver"
+  # Use clang/lld for better optimization and faster linking
+  export CC=clang
+  export CXX=clang++
+
+  # Use sccache if available for faster compilation
+  if command -v sccache &>/dev/null; then
+    export CC="sccache clang"
+    export CXX="sccache clang++"
+  fi
+
   export CFLAGS="-O3 -march=native -mtune=native -flto=auto -ffat-lto-objects -pipe -fno-plt"
-  export LDFLAGS="-flto=auto -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,-z,pack-relative-relocs"
+  export LDFLAGS="-flto=auto -fuse-ld=lld -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,-z,pack-relative-relocs"
   local -A tls=([rustls]="--with-rustls" [openssl]="--with-openssl" [wolfssl]="--with-wolfssl")
   for b in rustls openssl wolfssl; do
     mkdir -p "build-$b"

--- a/ffmpeg/PKGBUILD
+++ b/ffmpeg/PKGBUILD
@@ -26,7 +26,7 @@ depends=(
   x264 x265 libjxl
 )
 makedepends=(
-  avisynthplus clang nasm git ladspa cmake
+  avisynthplus clang lld nasm git ladspa cmake
   libgl mesa opencl-headers vulkan-headers ffnvcodec-headers
   lv2 gmp patch
 )
@@ -64,6 +64,17 @@ prepare() {
 
 build() {
   cd "$_pkgname-$pkgver"
+  # Use clang/lld for better optimization and faster linking
+  export CC=clang
+  export CXX=clang++
+  export LD=ld.lld
+
+  # Use sccache if available for faster compilation
+  if command -v sccache &>/dev/null; then
+    export CC="sccache clang"
+    export CXX="sccache clang++"
+  fi
+
   # Compiler settings for optimization (based on FFmpeg-Builds optimizations)
   # -O3: Maximum optimization level for performance
   # -march=native: Optimize for current CPU architecture (enables AVX512 if available)
@@ -77,7 +88,7 @@ build() {
   # -fvisibility=hidden: Hide symbols by default (reduces binary size)
   # -fno-semantic-interposition: Allow more aggressive optimizations
   # -D_FORTIFY_SOURCE=2: Runtime buffer overflow detection
-  export CFLAGS="-O3 -march=native -mtune=native -pipe -fno-plt -flto=auto -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fstack-protector-strong -fcf-protection -fvisibility=hidden -fno-semantic-interposition" CXXFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto"
+  export CFLAGS="-O3 -march=native -mtune=native -pipe -fno-plt -flto=auto -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fstack-protector-strong -fcf-protection -fvisibility=hidden -fno-semantic-interposition" CXXFLAGS="$CFLAGS" LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto -fuse-ld=lld"
   ./configure --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-shared --enable-gpl --enable-version3 --enable-nonfree --enable-lto \
     --enable-fontconfig --enable-gmp --enable-gnutls --enable-ladspa --enable-libaom --enable-libaribb24 --enable-libass --enable-libbluray \
     --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libdvdnav --enable-libdvdread --enable-libfreetype --enable-libfribidi \

--- a/mpv/PKGBUILD
+++ b/mpv/PKGBUILD
@@ -60,6 +60,8 @@ makedepends=(
     'python-docutils'
     'vulkan-headers'
     'wayland-protocols'
+    'clang'
+    'lld'
     # for satisfying pkgcheck:
     'python-pyqt6'
     'python-pyqtgraph')
@@ -83,6 +85,17 @@ prepare() {
 }
 
 build() {
+    # Use clang/lld for better optimization and faster linking
+    export CC=clang
+    export CXX=clang++
+    export LDFLAGS="${LDFLAGS} -fuse-ld=lld"
+
+    # Use sccache if available for faster compilation
+    if command -v sccache &>/dev/null; then
+        export CC="sccache clang"
+        export CXX="sccache clang++"
+    fi
+
     arch-meson "mpv-${pkgver}" build \
         -Dgpl='true' \
         -Dcplayer='true' \

--- a/obs-studio/PKGBUILD
+++ b/obs-studio/PKGBUILD
@@ -9,7 +9,7 @@ url="https://obsproject.com"
 license=('GPL2')
 depends=('ffmpeg' 'pipewire' 'rnnoise' 'libxcomposite'
   'libxinerama' 'libxkbcommon-x11' 'pciutils' 'mbedtls' 'qt6-svg')
-makedepends=('extra-cmake-modules' 'ffnvcodec-headers' 'nlohmann-json' 'simde' 'uthash' 'vulkan-headers')
+makedepends=('extra-cmake-modules' 'ffnvcodec-headers' 'nlohmann-json' 'simde' 'uthash' 'vulkan-headers' 'clang' 'lld')
 optdepends=(
   'v4l2loopback-dkms: virtual camera support'
 )
@@ -27,9 +27,19 @@ prepare() {
 }
 
 build() {
+  # Use clang/lld for better optimization and faster linking
+  export CC=clang
+  export CXX=clang++
+
+  # Use sccache if available for faster compilation
+  if command -v sccache &>/dev/null; then
+    export CC="sccache clang"
+    export CXX="sccache clang++"
+  fi
+
   export CFLAGS="${CFLAGS} -O3 -march=native -mtune=native -pipe -fno-plt -flto=auto"
   export CXXFLAGS="${CXXFLAGS} -O3 -march=native -mtune=native -pipe -fno-plt -flto=auto -Wno-error=deprecated-declarations"
-  export LDFLAGS="${LDFLAGS} -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
+  export LDFLAGS="${LDFLAGS} -fuse-ld=lld -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
   cmake -B build -S "${pkgname}-${pkgver}-sources" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_JACK=ON -DENABLE_SNDIO=OFF -DENABLE_BROWSER=OFF -DENABLE_VST=OFF -DENABLE_VLC=OFF -DENABLE_LIBFDK=OFF -DENABLE_WEBRTC=OFF -DENABLE_WEBSOCKET=OFF -DENABLE_NEW_MPEGTS_OUTPUT=OFF -DENABLE_AJA=OFF -DENABLE_SCRIPTING=OFF -DOBS_VERSION_OVERRIDE="$pkgver" -Wno-dev
   cmake --build build --target all -j"$(nproc)"
 }


### PR DESCRIPTION
This commit integrates sccache for compilation caching and enforces the use of clang/lld across multiple packages for better performance.

Changes:
- ffmpeg: Add clang/lld to makedepends, use sccache wrapper for CC/CXX
- mpv: Add clang/lld to makedepends, configure for meson builds
- curl: Add clang/lld to makedepends, use sccache and lld linker
- obs-studio: Add clang/lld to makedepends, use sccache for cmake builds
- chromium: Add sccache wrapper when using system clang

Workflow improvements (.github/workflows/build.yml):
- Specify sccache version for consistency (v0.9.0)
- Add LLVM toolchain env vars (AR, NM, RANLIB) for standard builds
- Enable SCCACHE_GHA_ENABLED explicitly in makepkg environment

Benefits:
- Faster incremental builds via sccache compilation caching
- Better optimization with clang/LLVM
- Faster linking with lld (LLVM linker)
- Consistent toolchain across all C/C++ packages

Note: .SRCINFO files will be auto-generated by CI workflow