### PR TITLE
Fix dependency extraction bug in Docker build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ build_docker() {
     set -euo pipefail
     pacman -Syu --noconfirm --needed base-devel pacman-contrib sudo
     # Optimized dependency extraction (single awk pass)
-    deps=$(makepkg --printsrcinfo 2>/dev/null | awk "/^\s*(make)?depends\s*=/ {sub(/^[[:space:]]+/, \"\", \$2); print \$2}" | tr "\n" " ")
+    deps=$(makepkg --printsrcinfo 2>/dev/null | awk "/^[[:space:]]*(make)?depends[[:space:]]*=/ {print \$3}" | tr "\n" " ")
     [[ -n "$deps" ]] && pacman -S --noconfirm --needed $deps
     useradd -m builder
     printf "builder ALL=(ALL) NOPASSWD:ALL\n" >/etc/sudoers.d/builder


### PR DESCRIPTION
The awk command was incorrectly extracting field $2 (the '=' symbol) instead of $3 (the actual package name) from .SRCINFO format.

.SRCINFO format: `<tab>depends = package-name`
- Field $1: 'depends' or 'makedepends'
- Field $2: '='
- Field $3: 'package-name' (correct field to extract)

This bug caused Docker builds to fail or skip dependency installation since it was trying to install '=' instead of the actual packages.

Changes:
- Fixed awk to extract $3 instead of $2
- Replaced \s with [[:space:]] for better POSIX compatibility
- Removed unnecessary sub() operation

Tested with aria2/.SRCINFO:
- Before: "= = = = = ="
- After: "openssl libxml2 sqlite c-ares ca-certificates libssh2"