### PR TITLE
Resolve geckoview-lite TODO in Firefox mozconfig

### DIFF
--- a/firefox/mozconfig
+++ b/firefox/mozconfig
@@ -3,7 +3,7 @@ ac_add_options --prefix=/usr
 ac_add_options --with-wasi-sysroot=/usr/share/wasi-sysroot
 export MOZ_INCLUDE_SOURCE_INFO=1
 
-# TODO: investigate "ac_add_options --enable-geckoview-lite"
+# Note: --enable-geckoview-lite is Android-only (GeckoView) and not applicable to desktop builds.
 ac_add_options --without-wasm-sandboxed-libraries
 ac_add_options --enable-application=browser
 ac_add_options --disable-artifact-builds


### PR DESCRIPTION
Investigated the `--enable-geckoview-lite` build option and confirmed it is specific to GeckoView (Android) and not applicable to desktop Firefox builds. Updated `firefox/mozconfig` to replace the TODO comment with a technical note to prevent future confusion. Verified the modification using `./vp-dev.py check`.

Fixes #92

---
*PR created automatically by Jules for task [15522190491707963838](https://jules.google.com/task/15522190491707963838) started by @Ven0m0*