### PR TITLE
Remove deprecated clipboard read permission from code permissions

### DIFF
--- a/code/microphone.patch
+++ b/code/microphone.patch
@@ -16,10 +16,10 @@ index 588e1cb..751230d 100644
  		]);
  
  		const allowedPermissionsInCore = new Set([
-@@ -186,6 +188,7 @@ export class CodeApplication extends Disposable {
- 			// TODO(deepak1556): Should be removed once migration is complete
- 			// https://github.com/microsoft/vscode/issues/239228
- 			'deprecated-sync-clipboard-read',
+@@ -186,6 +188,4 @@ export class CodeApplication extends Disposable {
+-			// TODO(deepak1556): Should be removed once migration is complete
+-			// https://github.com/microsoft/vscode/issues/239228
+-			'deprecated-sync-clipboard-read',
 +			'microphone'
  		]);
  


### PR DESCRIPTION
As requested, the `'deprecated-sync-clipboard-read'` permission and its associated TODO comments have been removed from the `allowedPermissionsInCore` block inside the `code/microphone.patch` file since the related clipboard migration has been completed. This ensures the deprecated permission is properly stripped during the code application patching phase.

---
*PR created automatically by Jules for task [7836732199065561279](https://jules.google.com/task/7836732199065561279) started by @Ven0m0*