### PR TITLE
🔒 [security fix] Add timeout to AUR API requests in find_updates.py

### DIFF
--- a/find_updates.py
+++ b/find_updates.py
@@ -488,19 +488,24 @@ class InfoResult:
 
 handle = None
 aur_url = "https://aur.archlinux.org/rpc/v5"
+AUR_REQUEST_TIMEOUT = 10
 
 local_repos = {"custom", "loathk-public", "loathk-personal"}
 arch_repos = {"core", "extra", "community", "multilib"}
 
 
 def search_single(name: str):
-    response = requests.get(f"{aur_url}/search/{name}?by=name")
+    response = requests.get(
+        f"{aur_url}/search/{name}?by=name", timeout=AUR_REQUEST_TIMEOUT
+    )
     return SearchResult.from_dict((json.loads(response.content)))
 
 
 def info_multiple(names: List[str]):
     payload = {"arg[]": names}
-    response = requests.get(f"{aur_url}/info", params=payload)
+    response = requests.get(
+        f"{aur_url}/info", params=payload, timeout=AUR_REQUEST_TIMEOUT
+    )
     return InfoResult.from_dict(json.loads(response.content))
 
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the lack of a timeout on network requests to the Arch User Repository (AUR) API.
⚠️ **Risk:** Without a timeout, `find_updates.py` could hang indefinitely if the AUR server is slow or unresponsive, potentially leading to resource exhaustion or blocked automation.
🛡️ **Solution:** Introduced a global `AUR_REQUEST_TIMEOUT` constant (10 seconds) and updated all `requests.get` calls to utilize it. Verified the fix with unit tests using mocks.

---
*PR created automatically by Jules for task [4486610982783659702](https://jules.google.com/task/4486610982783659702) started by @Ven0m0*