### PR TITLE
🧹 Abstract duplicate parallel loop logic

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -53,6 +53,49 @@ wait_for_jobs() {
   done
 }
 
+# ─── Parallel/Serial Batch Execution Helper ──────────────────────────────────
+# Run tasks in batch (parallel or serial) for list of directories
+# Usage: run_task_batch "$parallel" "$max_jobs" "handler_func" "errs_var" "items_var" "pre_task_func" "processor_func"
+run_task_batch() {
+  local parallel=$1 max_jobs=$2 handler=$3 errs_var=$4 items_var=$5 pre_task=$6 processor=$7
+  local -n items_ref=$items_var
+
+  if [[ $parallel == true ]]; then
+    local -a pids=()
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
+
+    for item in "${items_ref[@]}"; do
+      [[ -d "$item" ]] || continue
+
+      wait_for_jobs "$max_jobs"
+
+      if [[ -n $pre_task ]]; then "$pre_task" "$item"; fi
+
+      ("$processor" "$item" >"$tmpdir/${item//\//_}.log" 2>&1) &
+      pids+=($!)
+    done
+
+    for pid in "${pids[@]}"; do wait "$pid" || true; done
+
+    for logfile in "$tmpdir"/*.log; do
+      [[ -f $logfile ]] || continue
+      "$handler" "$errs_var" <"$logfile"
+    done
+  else
+    for item in "${items_ref[@]}"; do
+      [[ -d "$item" ]] || continue
+
+      if [[ -n $pre_task ]]; then "$pre_task" "$item"; fi
+
+      local output
+      output=$("$processor" "$item" 2>&1)
+      "$handler" "$errs_var" <<<"$output"
+    done
+  fi
+}
+
 # ─── Script Directory ────────────────────────────────────────────────────────
 # Get the directory of the calling script
 # Usage: cd_to_script_dir

--- a/pkg.sh
+++ b/pkg.sh
@@ -394,40 +394,10 @@ cmd_lint() {
 
   printf 'Linting %d package(s) [parallel=%s, max_jobs=%d]\n' "${#pkgs[@]}" "$parallel" "$max_jobs"
 
-  if [[ $parallel == true ]]; then
-    local -a pids=()
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' EXIT
+  _lint_pre() { printf '==> %s\n' "$1"; }
+  _lint_proc() { lint_pkg "$1" "$root" "$sc" "$sh" "$sf" "$nc"; }
 
-    for pkg in "${pkgs[@]}"; do
-      [[ -d $pkg ]] || continue
-
-      wait_for_jobs "$max_jobs"
-
-      printf '==> %s\n' "$pkg"
-      (lint_pkg "$pkg" "$root" "$sc" "$sh" "$sf" "$nc" >"$tmpdir/$pkg.log" 2>&1) &
-      pids+=($!)
-    done
-
-    for pid in "${pids[@]}"; do
-      wait "$pid" || true
-    done
-
-    for logfile in "$tmpdir"/*.log; do
-      [[ -f $logfile ]] || continue
-      handle_lint_output errs <"$logfile"
-    done
-  else
-    for pkg in "${pkgs[@]}"; do
-      [[ -d $pkg ]] || continue
-      printf '==> %s\n' "$pkg"
-
-      local output
-      output=$(lint_pkg "$pkg" "$root" "$sc" "$sh" "$sf" "$nc" 2>&1)
-      handle_lint_output errs <<<"$output"
-    done
-  fi
+  run_task_batch "$parallel" "$max_jobs" handle_lint_output errs pkgs _lint_pre _lint_proc
 
   if [[ ${#errs[@]} -gt 0 ]]; then
     printf '\n%bFound %s error(s)%b\n' "$R" "${#errs[@]}" "$D" >&2
@@ -495,38 +465,9 @@ cmd_srcinfo() {
 
   log "Processing ${#pkgs[@]} package(s) [parallel=$parallel, max_jobs=$max_jobs]"
 
-  if [[ $parallel == true ]]; then
-    local -a pids=()
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' EXIT
+  _srcinfo_proc() { process_srcinfo_pkg "$1" "$root"; }
 
-    for pkg in "${pkgs[@]}"; do
-      [[ ! -d $pkg ]] && continue
-
-      wait_for_jobs "$max_jobs"
-
-      (process_srcinfo_pkg "$pkg" "$root" >"$tmpdir/$pkg.log" 2>&1) &
-      pids+=($!)
-    done
-
-    for pid in "${pids[@]}"; do
-      wait "$pid" || true
-    done
-
-    for logfile in "$tmpdir"/*.log; do
-      [[ -f $logfile ]] || continue
-      handle_srcinfo_output errs <"$logfile"
-    done
-  else
-    for pkg in "${pkgs[@]}"; do
-      [[ ! -d $pkg ]] && continue
-
-      local output
-      output=$(process_srcinfo_pkg "$pkg" "$root" 2>&1)
-      handle_srcinfo_output errs <<<"$output"
-    done
-  fi
+  run_task_batch "$parallel" "$max_jobs" handle_srcinfo_output errs pkgs "" _srcinfo_proc
 
   if [[ ${#errs[@]} -gt 0 ]]; then
     err "Failed to process ${#errs[@]} package(s)"


### PR DESCRIPTION
🎯 **What:** Extracted the parallel batch execution logic from `cmd_lint` and `cmd_srcinfo` into a new helper function `run_task_batch` in `lib/helpers.sh`.
💡 **Why:** Improves maintainability by removing over 60 lines of duplicated execution boilerplate, centralizing job execution.
✅ **Verification:** Ran `pkg.sh lint` and `pkg.sh srcinfo` which executes over the same packages and formats output identically, and verified python linting passes.
✨ **Result:** Cleaner code, less duplication, consistent async logic.

---
*PR created automatically by Jules for task [10705435494056145153](https://jules.google.com/task/10705435494056145153) started by @Ven0m0*