### PR TITLE
🔒 Fix arbitrary code execution vulnerability in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,6 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ matrix.pkg }}"
-          source PKGBUILD
           PKGFILE=""
           PKGFILE_PATH=""
           # Handle both standard and Docker builds
@@ -264,12 +263,26 @@ jobs:
             echo "Error: Package file not found"
             exit 1
           fi
+
+          # Extract variables safely from the built package filename
+          # Format: pkgname-[epoch:]pkgver-pkgrel-arch.pkg.tar.*
+          base="${PKGFILE%.pkg.tar.*}"
+          arch="${base##*-}"
+          base="${base%-*}"
+          pkgrel="${base##*-}"
+          base="${base%-*}"
+          pkgver="${base##*-}"
+          pkgname="${base%-*}"
+
+          # Remove epoch from pkgver for the TAG creation
+          pkgver_no_epoch="${pkgver#*:}"
+
           {
             echo "PKGNAME=${pkgname}"
             echo "PKGVER=${pkgver}"
             echo "PKGREL=${pkgrel}"
             echo "PKGFILE=${PKGFILE}"
-            echo "TAG=v${pkgver}-${pkgrel}"
+            echo "TAG=v${pkgver_no_epoch}-${pkgrel}"
           } >> "$GITHUB_OUTPUT"
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,10 @@
+🔒 Fix GitHub Actions code execution vulnerability
+
+🎯 **What:**
+Removed the `source PKGBUILD` command in `.github/workflows/build.yml` and replaced it with a safe bash string manipulation script to extract package variables directly from the generated package filename.
+
+⚠️ **Risk:**
+By sourcing an untrusted arbitrary file (`PKGBUILD`) in the CI environment without a sandbox, a malicious actor or an compromised dependency could exfiltrate secrets and obtain uncontrolled execution within the runner.
+
+🛡️ **Solution:**
+The updated logic leverages native string parsing on the built package file (`pkgname-[epoch:]pkgver-pkgrel-arch.pkg.tar.*`). This allows us to securely extract the necessary metadata (package name, version, release) to generate GitHub tags and artifacts without executing potentially malicious code. Tested with epochs and hyphens properly.


### PR DESCRIPTION
🔒 Fix GitHub Actions code execution vulnerability

🎯 **What:** 
Removed the `source PKGBUILD` command in `.github/workflows/build.yml` and replaced it with a safe bash string manipulation script to extract package variables directly from the generated package filename.

⚠️ **Risk:** 
By sourcing an untrusted arbitrary file (`PKGBUILD`) in the CI environment without a sandbox, a malicious actor or an compromised dependency could exfiltrate secrets and obtain uncontrolled execution within the runner.

🛡️ **Solution:** 
The updated logic leverages native string parsing on the built package file (`pkgname-[epoch:]pkgver-pkgrel-arch.pkg.tar.*`). This allows us to securely extract the necessary metadata (package name, version, release) to generate GitHub tags and artifacts without executing potentially malicious code. Tested with epochs and hyphens properly.

---
*PR created automatically by Jules for task [2405081361382850085](https://jules.google.com/task/2405081361382850085) started by @Ven0m0*