### PR TITLE
java/java-openjdk: Remove obsolete -fexceptions workaround

### DIFF
--- a/java/java-openjdk/PKGBUILD
+++ b/java/java-openjdk/PKGBUILD
@@ -118,14 +118,6 @@ build() {
     _CXXFLAGS=${CXXFLAGS/-fno-plt/}
   fi
 
-  # TODO: Should be rechecked for the next releases
-  # compiling with -fexceptions leads to:
-  # /usr/bin/ld: /build/java-openjdk/src/jdk17u-jdk-17.0.3-2/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/zPhysicalMemory.o: in function `ZList<ZMemory>::~ZList()':
-  # /build/java-openjdk/src/jdk17u-jdk-17.0.3-2/src/hotspot/share/gc/z/zList.hpp:54: undefined reference to `ZListNode<ZMemory>::~ZListNode()'
-  # collect2: error: ld returned 1 exit status
-  _CFLAGS=${CFLAGS/-fexceptions/}
-  _CXXFLAGS=${CXXFLAGS/-fexceptions/}
-
   # CFLAGS, CXXFLAGS and LDFLAGS are ignored as shown by a warning
   # in the output of ./configure unless used like such:
   #  --with-extra-cflags="${CFLAGS}"


### PR DESCRIPTION
Removes an obsolete workaround that stripped `-fexceptions` from `CFLAGS` and `CXXFLAGS` when building `java-openjdk`. This was previously necessary due to a GCC/OpenJDK bug, but versions 25+ build fine with `-fexceptions`. Also fixes a logical bug where the strip operation was overwriting the architecture-specific flags like `-O3` because it was reading from the global `CFLAGS` instead of the local `_CFLAGS`.

---
*PR created automatically by Jules for task [9144425702744148925](https://jules.google.com/task/9144425702744148925) started by @Ven0m0*