### PR TITLE
Remove obsolete -fexceptions workaround in java-openjdk

### DIFF
--- a/java/java-openjdk/PKGBUILD
+++ b/java/java-openjdk/PKGBUILD
@@ -114,17 +114,10 @@ build() {
   local _LDFLAGS=${LDFLAGS}
   if [[ ${CARCH} = i686 ]]; then
     echo "Removing '-fno-plt' from CFLAGS and CXXFLAGS to prevent build fail with this architecture"
-    _CFLAGS=${CFLAGS/-fno-plt/}
-    _CXXFLAGS=${CXXFLAGS/-fno-plt/}
+    _CFLAGS=${_CFLAGS/-fno-plt/}
+    _CXXFLAGS=${_CXXFLAGS/-fno-plt/}
   fi
 
-  # TODO: Should be rechecked for the next releases
-  # compiling with -fexceptions leads to:
-  # /usr/bin/ld: /build/java-openjdk/src/jdk17u-jdk-17.0.3-2/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/zPhysicalMemory.o: in function `ZList<ZMemory>::~ZList()':
-  # /build/java-openjdk/src/jdk17u-jdk-17.0.3-2/src/hotspot/share/gc/z/zList.hpp:54: undefined reference to `ZListNode<ZMemory>::~ZListNode()'
-  # collect2: error: ld returned 1 exit status
-  _CFLAGS=${CFLAGS/-fexceptions/}
-  _CXXFLAGS=${CXXFLAGS/-fexceptions/}
 
   # CFLAGS, CXXFLAGS and LDFLAGS are ignored as shown by a warning
   # in the output of ./configure unless used like such:


### PR DESCRIPTION
This change removes the workaround that stripped `-fexceptions` from compiler flags in the `java-openjdk` PKGBUILD, as it is no longer necessary for newer JDK releases. Additionally, it refactors the `i686` flag modification to be cumulative by using local variables, preventing the accidental loss of other flag adjustments.

---
*PR created automatically by Jules for task [8340617909678659961](https://jules.google.com/task/8340617909678659961) started by @Ven0m0*