### PR TITLE
🧪 Add tests for vp-dev.py _parse_pkg method

### DIFF
--- a/tests/test_vp_dev.py
+++ b/tests/test_vp_dev.py
@@ -1,0 +1,131 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Load vp-dev.py module
+spec = importlib.util.spec_from_file_location("vp_dev", "vp-dev.py")
+vp_dev = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vp_dev)
+
+class TestVpDevParsePkg(unittest.TestCase):
+    def setUp(self):
+        self.vp = vp_dev.VpDev()
+
+    @patch('pathlib.Path.exists')
+    def test_parse_pkg_not_exists(self, mock_exists):
+        mock_exists.return_value = False
+        self.assertIsNone(self.vp._parse_pkg(Path('nonexistent')))
+
+    @patch('pathlib.Path.exists')
+    @patch('subprocess.run')
+    def test_parse_pkg_success_git_fallback(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        # Mock bash -c ...
+        mock_run1 = MagicMock()
+        mock_run1.returncode = 0
+        mock_run1.stdout = "mypkg|1.0.0|1|My Description|https://example.com"
+
+        # Mock git ls-files fallback via _git method logic
+        mock_run2 = MagicMock()
+        mock_run2.returncode = 0
+        mock_run2.stdout = "file1.patch\nfile2.txt\n"
+
+        mock_run.side_effect = [mock_run1, mock_run2]
+
+        result = self.vp._parse_pkg(Path('/mock/PKGBUILD'))
+
+        self.assertEqual(result, {
+            'name': 'mypkg',
+            'version': '1.0.0-1',
+            'description': 'My Description',
+            'url': 'https://example.com',
+            'files': ['file1.patch', 'file2.txt']
+        })
+
+    @patch('pathlib.Path.exists')
+    @patch('subprocess.run')
+    def test_parse_pkg_subprocess_failure(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        # Mock bash -c failing
+        mock_run1 = MagicMock()
+        mock_run1.returncode = 1
+        mock_run1.stdout = ""
+
+        mock_run.return_value = mock_run1
+
+        self.assertIsNone(self.vp._parse_pkg(Path('/mock/PKGBUILD')))
+
+    @patch('pathlib.Path.exists')
+    @patch('subprocess.run')
+    def test_parse_pkg_malformed_output(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        # Output has less than 4 parts
+        mock_run1 = MagicMock()
+        mock_run1.returncode = 0
+        mock_run1.stdout = "mypkg|1.0.0|1"
+
+        mock_run.return_value = mock_run1
+
+        self.assertIsNone(self.vp._parse_pkg(Path('/mock/PKGBUILD')))
+
+    @patch('pathlib.Path.exists')
+    @patch('subprocess.run')
+    def test_parse_pkg_with_files_cache(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        mock_run1 = MagicMock()
+        mock_run1.returncode = 0
+        mock_run1.stdout = "mypkg|1.0.0|1|My Description|https://example.com"
+
+        mock_run.return_value = mock_run1
+
+        # Populate files cache
+        pb_path = Path('/mock/PKGBUILD')
+        self.vp.files_cache = {
+            pb_path.parent: ['PKGBUILD', 'file_cache_1.txt', 'file_cache_2.patch']
+        }
+
+        result = self.vp._parse_pkg(pb_path)
+
+        # Verify it uses files_cache instead of calling git
+        self.assertEqual(mock_run.call_count, 1) # Only bash -c called, no git ls-files
+        self.assertEqual(result, {
+            'name': 'mypkg',
+            'version': '1.0.0-1',
+            'description': 'My Description',
+            'url': 'https://example.com',
+            'files': ['file_cache_1.txt', 'file_cache_2.patch']
+        })
+
+    @patch('pathlib.Path.exists')
+    @patch('subprocess.run')
+    def test_parse_pkg_missing_url(self, mock_run, mock_exists):
+        mock_exists.return_value = True
+
+        # Output has exactly 4 parts (no url)
+        mock_run1 = MagicMock()
+        mock_run1.returncode = 0
+        mock_run1.stdout = "mypkg|1.0.0|1|My Description"
+
+        mock_run2 = MagicMock()
+        mock_run2.returncode = 0
+        mock_run2.stdout = "file1.patch\n"
+
+        mock_run.side_effect = [mock_run1, mock_run2]
+
+        result = self.vp._parse_pkg(Path('/mock/PKGBUILD'))
+
+        self.assertEqual(result, {
+            'name': 'mypkg',
+            'version': '1.0.0-1',
+            'description': 'My Description',
+            'url': '',
+            'files': ['file1.patch']
+        })
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `_parse_pkg` method in `vp-dev.py` was an untested public API, posing a risk during refactoring or environment changes. Testing required setting up a mock directory with a fake PKGBUILD or mocking `subprocess.run`, which is why it was previously omitted.
📊 **Coverage:** Successfully added comprehensive tests verifying:
  - File doesn't exist returning `None`.
  - Subprocess failure returning `None`.
  - Malformed bash output returning `None`.
  - Cache hit logic (preventing extra git subcommands).
  - Git fallback and successfully returning a populated dictionary.
  - Correct execution and dictionary structures even without specific variables like `url`.
✨ **Result:** Enhanced the testing coverage and stability of `vp-dev.py`. The addition of these tests ensures any future modifications to package parsing won't inadvertently break core logic.

---
*PR created automatically by Jules for task [3176187938942933540](https://jules.google.com/task/3176187938942933540) started by @Ven0m0*