### PR TITLE
java21-openjdk: package jtreg for check() function

### DIFF
--- a/java/java21-openjdk/PKGBUILD
+++ b/java/java21-openjdk/PKGBUILD
@@ -2,8 +2,6 @@
 # Maintainer: Frederik Schwan <freswa at archlinux dot org>
 # Contributor: Guillaume ALAUX <guillaume@archlinux.org>
 
-# TODO add test, see about packaging jtreg and using it here
-
 pkgbase=java21-openjdk
 pkgname=(
   jre21-openjdk-headless
@@ -50,6 +48,7 @@ makedepends=(
   unzip
   zip
 )
+checkdepends=('jtreg')
 # https://bugs.openjdk.org/browse/JDK-8340215
 options=(
   !lto
@@ -158,8 +157,7 @@ build() {
 
 check() {
   cd ${_jdkdir}
-  # TODO package jtreg
-  # make -k check
+  make -k check
 }
 
 package_jre21-openjdk-headless() {


### PR DESCRIPTION
This PR adds the `jtreg` testing package to the `checkdepends` of the `java21-openjdk` package and uncomments `make -k check` in the `check()` block. It also cleans up some outdated TODO comments indicating that `jtreg` needed to be packaged.

---
*PR created automatically by Jules for task [16223271602244399659](https://jules.google.com/task/16223271602244399659) started by @Ven0m0*