### PR TITLE
Fix log-file glob and strengthen clean() test assertions (PR #243 follow-up)

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -73,13 +73,13 @@ run_task_batch() {
 
       if [[ -n $pre_task ]]; then "$pre_task" "$item"; fi
 
-      ("$processor" "$item" >"$tmpdir/${item//\//_}.log" 2>&1) &
+      ("$processor" "$item" >"$tmpdir/job_${item//\//_}.log" 2>&1) &
       pids+=($!)
     done
 
     for pid in "${pids[@]}"; do wait "$pid" || true; done
 
-    for logfile in "$tmpdir"/*.log; do
+    for logfile in "$tmpdir"/job_*.log; do
       [[ -f $logfile ]] || continue
       "$handler" "$errs_var" <"$logfile"
     done

--- a/tests/test_vp_dev.py
+++ b/tests/test_vp_dev.py
@@ -420,6 +420,8 @@ class TestVpDev(unittest.TestCase):
 
         result = self.vd.clean()
         self.assertEqual(result, 0)
+        mock_file.unlink.assert_called_once()
+        mock_rmtree.assert_called_once_with(mock_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two fixes for review comments on #243:

- **lib/helpers.sh**: prefix parallel job log files with `job_` so the `*.log` glob collects them when `item` resolves to `.` (dot-files are skipped by bash's default glob expansion without `dotglob`)
- **tests/test_vp_dev.py**: add `mock_file.unlink.assert_called_once()` and `mock_rmtree.assert_called_once_with(mock_dir)` in `test_clean` to verify actual side effects, not just the return code

Note: the `java/java-openjdk` CI failures are a pre-existing infrastructure issue (`pacman-key needs to be run as root`) unrelated to the PKGBUILD changes in #243.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhFVq1iXexRFM4h2psJdZc)_