### PR TITLE
Fix GitHub token usage and Kilo PATH setup in agent workflow

### DIFF
--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -145,14 +145,10 @@ jobs:
           OPENCODE_EXPERIMENTAL_OXFMT: "true"
           MORPH_TIMEOUT: "60000"
           MORPH_MODEL: morph-v3-fast
-          # Pin opencode binary: v1.15.6 broke opencode/* model auth
-          # (requires OIDC console token instead of OPENCODE_API_KEY).
-          # The install script inherits VERSION and installs this exact release.
-          VERSION: "1.14.51"
         with:
           model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5-free' }}
           prompt: ${{ inputs.prompt }}
-          use_github_token: true
+          use_github_token: false
 
       - name: Get Kilo version
         if: inputs.provider == 'kilo'

--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -189,9 +189,11 @@ jobs:
       - name: Install Kilo CLI
         if: inputs.provider == 'kilo' && steps.kilo-cache.outputs.cache-hit != 'true'
         shell: bash
-        run: |
-          curl -fsSL https://kilo.ai/cli/install | bash
-          echo "$HOME/.kilo/bin" >> "$GITHUB_PATH"
+        run: curl -fsSL https://kilo.ai/cli/install | bash
+      - name: Add Kilo to PATH
+        if: inputs.provider == 'kilo'
+        shell: bash
+        run: echo "$HOME/.kilo/bin" >> "$GITHUB_PATH"
       - name: Run Kilo
         if: inputs.provider == 'kilo'
         shell: bash

--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -145,6 +145,10 @@ jobs:
           OPENCODE_EXPERIMENTAL_OXFMT: "true"
           MORPH_TIMEOUT: "60000"
           MORPH_MODEL: morph-v3-fast
+          # Pin opencode binary: v1.15.6 broke opencode/* model auth
+          # (requires OIDC console token instead of OPENCODE_API_KEY).
+          # The install script inherits VERSION and installs this exact release.
+          VERSION: "1.14.51"
         with:
           model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5-free' }}
           prompt: ${{ inputs.prompt }}

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "kilo/kilo-auto/frontier"
+      model: "opencode/minimax-m2.5-free"
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}
@@ -43,5 +43,4 @@ jobs:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
-      KILO_ORG_ID: ${{ secrets.KILO_ORG_ID }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "opencode/minimax-m2.5-free"
+      model: "kilo/kilo-auto/frontier"
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}
@@ -43,4 +43,5 @@ jobs:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
+      KILO_ORG_ID: ${{ secrets.KILO_ORG_ID }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary
Corrects two issues in the `_run-agent.yml` workflow: disables GitHub token usage for the code generation step and refactors the Kilo CLI installation to properly set up the PATH in a separate step.

## Key changes
- Disable GitHub token for OpenCode API calls by setting `use_github_token: false` (was `true`)
- Split Kilo CLI installation into two steps:
  - Step 1: Install Kilo CLI via curl
  - Step 2: Add Kilo binary directory to `$GITHUB_PATH` in a separate step with proper conditional

## Implementation details
The PATH setup is now in its own step with the `if: inputs.provider == 'kilo'` condition, ensuring the PATH modification is applied whenever Kilo is the selected provider, independent of cache status. This improves reliability of the Kilo CLI availability in subsequent workflow steps.

https://claude.ai/code/session_01Xf4S64p2MEdgARWWrdjPLp