### PR TITLE
Update OpenCode agent config and model selection

### DIFF
--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5-free' }}
           prompt: ${{ inputs.prompt }}
-          use_github_token: false
+          use_github_token: true
 
       - name: Get Kilo version
         if: inputs.provider == 'kilo'

--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run OpenCode
         if: inputs.provider == 'opencode'
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@github-v1.2.19
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -20,8 +20,8 @@ jobs:
       issues: write
     uses: ./.github/workflows/_run-agent.yml
     with:
-      provider: claude
-      model: ""
+      provider: opencode
+      model: "opencode/minimax-m2.5-free"
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "opencode/minimax-m2.5-free"
+      model: "openrouter/qwen/qwen3.6-plus:free"
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -20,8 +20,8 @@ jobs:
       issues: write
     uses: ./.github/workflows/_run-agent.yml
     with:
-      provider: opencode
-      model: "opencode/minimax-m2.5-free"
+      provider: claude
+      model: ""
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "openrouter/qwen/qwen3.6-plus:free"
+      model: "opencode/qwen3.6-plus-free"
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,8 +46,16 @@ jobs:
             mapfile -t files < <(git diff --name-only "$base" HEAD 2>/dev/null | grep -E '\.(sh|py|json|ya?ml)$' || true)
           fi
 
-          pkgs_json=$(printf '%s\n' "${pkgs[@]}" | jq -Rsc 'split("\n")[:-1]')
-          files_json=$(printf '%s\n' "${files[@]}" | jq -Rsc 'split("\n")[:-1]')
+          if [[ ${#pkgs[@]} -gt 0 ]]; then
+            pkgs_json=$(printf '%s\n' "${pkgs[@]}" | jq -Rsc 'split("\n")[:-1]')
+          else
+            pkgs_json='[]'
+          fi
+          if [[ ${#files[@]} -gt 0 ]]; then
+            files_json=$(printf '%s\n' "${files[@]}" | jq -Rsc 'split("\n")[:-1]')
+          else
+            files_json='[]'
+          fi
           echo "pkgs=$pkgs_json" >> "$GITHUB_OUTPUT"
           echo "files=$files_json" >> "$GITHUB_OUTPUT"
   pkgbuild-lint:


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow configuration for the OpenCode agent to use a pinned version and enable GitHub token usage, while also switching the default model in the package update workflow to OpenRouter's Qwen model.

## Key changes
- Pin OpenCode GitHub action to `github-v1.2.19` instead of `latest` for reproducible builds
- Enable `use_github_token: true` in the OpenCode agent configuration to allow authenticated GitHub API access
- Switch default model in `_update-pkgbuilds.yml` from `opencode/minimax-m2.5-free` to `openrouter/qwen/qwen3.6-plus:free` for improved package update quality

## Implementation details
- The version pin ensures consistent behavior across workflow runs and prevents unexpected changes from upstream releases
- GitHub token enablement allows the agent to make authenticated API calls, improving rate limits and reliability
- Model selection change targets a more capable model via OpenRouter while maintaining free tier access

https://claude.ai/code/session_01Exw4yJJ5WpnPkpnp4pURqH