### PR TITLE
Switch PKGBUILD update workflow to minimax-2.5 model

### DIFF
--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "opencode/qwen3.6-plus-free"
+      model: "opencode/minimax-2.5:free"
       prompt: |
         Update version-controlled PKGBUILDs and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package listed in nvchecker.toml.' }}


### PR DESCRIPTION
## Summary
Updates the automated PKGBUILD update workflow to use the `minimax-2.5:free` model instead of `opencode/qwen3.6-plus-free` for generating package update pull requests.

## Changes
- Updated the model parameter in `.github/workflows/_update-pkgbuilds.yml` from `opencode/qwen3.6-plus-free` to `opencode/minimax-2.5:free`
- This affects the AI model used by the `_run-agent.yml` workflow when processing package version updates and creating pull requests

## Details
The change switches the LLM provider/model used in the automated package update workflow. The `minimax-2.5:free` model will now handle the generation of PKGBUILD updates and associated pull request content for the nvchecker-driven package update process.

https://claude.ai/code/session_01NzcKS7E1mNiukTzfyt6GkP