### PR TITLE
Add fallback model support to OpenCode agent workflow

### DIFF
--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ""
+      fallback_model:
+        description: "OpenCode fallback model, tried only if the primary opencode run fails (blank = no fallback)"
+        required: false
+        type: string
+        default: ""
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -51,6 +56,11 @@ on:
         type: string
       model:
         description: "Model override (leave blank for provider default)"
+        required: false
+        type: string
+        default: ""
+      fallback_model:
+        description: "OpenCode fallback model, tried only if the primary opencode run fails (blank = no fallback)"
         required: false
         type: string
         default: ""
@@ -121,7 +131,11 @@ jobs:
           prompt: ${{ inputs.prompt }}
 
       - name: Run OpenCode
+        id: opencode
         if: inputs.provider == 'opencode'
+        # Only swallow the failure when a fallback model is configured, so a
+        # solo run still fails the job normally.
+        continue-on-error: ${{ inputs.fallback_model != '' }}
         uses: anomalyco/opencode/github@github-v1.2.25
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -147,6 +161,36 @@ jobs:
           MORPH_MODEL: morph-v3-fast
         with:
           model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5' }}
+          prompt: ${{ inputs.prompt }}
+          use_github_token: true
+
+      - name: Run OpenCode (fallback model)
+        if: inputs.provider == 'opencode' && inputs.fallback_model != '' && steps.opencode.outcome == 'failure'
+        uses: anomalyco/opencode/github@github-v1.2.25
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
+          KILO_ORG_ID: ${{ secrets.KILO_ORG_ID }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          OPENCODE_EXPERIMENTAL: "true"
+          OPENCODE_ENABLE_EXA: "1"
+          OPENCODE_EXPERIMENTAL_LSP_TOOL: "true"
+          OPENCODE_EXPERIMENTAL_MARKDOWN: "true"
+          OPENCODE_ENABLE_EXPERIMENTAL_MODELS: "true"
+          OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: "300000"
+          OPENCODE_EXPERIMENTAL_LAZY_TOOLS: "true"
+          OPENCODE_PRUNE_SCALE_WITH_CONTEXT: "true"
+          OPENCODE_DISABLE_FILETIME_CHECK: "true"
+          OPENCODE_DISABLE_CLAUDE_CODE_PROMPT: "1"
+          OPENCODE_DISABLE_AUTOUPDATE: "true"
+          OPENCODE_EXPERIMENTAL_OXFMT: "true"
+          MORPH_TIMEOUT: "60000"
+          MORPH_MODEL: morph-v3-fast
+        with:
+          model: ${{ inputs.fallback_model }}
           prompt: ${{ inputs.prompt }}
           use_github_token: true
 

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       provider: opencode
       model: "opencode/minimax-m3-free"
+      fallback_model: "opencode/deepseek-v4-flash-free"
       prompt: |
         Update version-controlled PKGBUILDs to their latest upstream versions and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package key in nvchecker.toml.' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# Minimal, non-destructive pre-commit config so pre-commit.ci has a valid
+# configuration to run. Heavy linting/formatting is handled by MegaLinter
+# (.mega-linter.yml); these hooks only validate syntax and catch common
+# mistakes, and never rewrite files.
+ci:
+  autofix_prs: false
+  autoupdate_schedule: monthly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+        # firefox/policies.json contains trailing commas (JSONC-style); leave
+        # it to MegaLinter rather than failing this lightweight syntax gate.
+        exclude: ^firefox/policies\.json$
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: [--maxkb=2048]


### PR DESCRIPTION
## Summary

Adds optional fallback model support to the `_run-agent.yml` reusable workflow, allowing a secondary OpenCode model to be attempted if the primary model fails. This improves reliability for automated tasks like package updates by gracefully degrading to an alternative model rather than failing the entire job.

## Key Changes

- **Workflow input parameter**: Added `fallback_model` input to both `workflow_call` triggers in `_run-agent.yml` with description and empty default
- **Error handling**: Modified the primary OpenCode step to use `continue-on-error` when a fallback model is configured, allowing the workflow to proceed to the fallback attempt instead of immediately failing
- **Fallback step**: Added new "Run OpenCode (fallback model)" step that executes only when:
  - Provider is `opencode`
  - A fallback model is specified
  - The primary OpenCode step failed
- **Package update workflow**: Updated `_update-pkgbuilds.yml` to pass `fallback_model: "opencode/deepseek-v4-flash-free"` when calling the agent workflow, providing a concrete fallback for automated PKGBUILD updates

## Implementation Details

- The fallback step is conditionally skipped when no fallback model is configured, preserving the original fail-fast behavior for solo runs
- Both the primary and fallback steps use identical environment variables and configuration, ensuring consistent behavior
- The fallback model parameter is optional and defaults to empty string, maintaining backward compatibility with existing callers

https://claude.ai/code/session_01FCfwtoVpnPYmEKXoGaK2Uw