### PR TITLE
Update PKGBUILD workflow to use nemotron-3-ultra model

### DIFF
--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "opencode/minimax-m3-free"
+      model: "opencode/nemotron-3-ultra-free"
       fallback_model: "opencode/deepseek-v4-flash-free"
       prompt: |
         Update version-controlled PKGBUILDs to their latest upstream versions and open one pull request.


### PR DESCRIPTION
## Summary
Updates the automated PKGBUILD update workflow to use a different AI model provider for generating package update pull requests.

## Changes
- **Model update**: Changed the primary model in `_update-pkgbuilds.yml` from `opencode/minimax-m3-free` to `opencode/nemotron-3-ultra-free`
- The fallback model (`opencode/deepseek-v4-flash-free`) remains unchanged

## Details
This change updates the AI model used by the automated PKGBUILD update agent workflow. The new model should provide improved performance for analyzing and updating package versions while maintaining the same fallback strategy for reliability.

https://claude.ai/code/session_017NCVnaHiSYd9hT66rynTRp