### PR TITLE
Update default model to minimax-m2.5-free and add small_model config

### DIFF
--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -160,7 +160,7 @@ jobs:
           MORPH_TIMEOUT: "60000"
           MORPH_MODEL: morph-v3-fast
         with:
-          model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5' }}
+          model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5-free' }}
           prompt: ${{ inputs.prompt }}
           use_github_token: false
 

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "instructions": ["instructions.md", "AGENTS.md"],
+  "small_model": "opencode/minimax-m3-free",
   "permission": {
     "*": "allow",
     "sudo *": "deny",


### PR DESCRIPTION
## Summary
Updates the default AI model configuration to use the free tier variant and adds a new `small_model` configuration option to the OpenCode config.

## Changes
- **Workflow default model**: Updated `.github/workflows/_run-agent.yml` to use `opencode/minimax-m2.5-free` instead of `opencode/minimax-m2.5` as the fallback model when no model is explicitly specified
- **OpenCode config**: Added `small_model` field to `.opencode/opencode.json` set to `opencode/minimax-m3-free` for use cases requiring a smaller/faster model variant

## Details
These changes align the agent workflow with free-tier model availability and provide configuration flexibility for tasks that benefit from smaller model variants while maintaining backward compatibility through the default fallback mechanism.

https://claude.ai/code/session_01XgiMgzp9N58otpiWw9WBLM