### PR TITLE
Switch OpenCode models to nemotron-3-ultra and improve fallback handling

### DIFF
--- a/.github/builder/opencode-config.json
+++ b/.github/builder/opencode-config.json
@@ -13,8 +13,8 @@
   },
   "share": "manual",
   "default_agent": "build",
-  "model": "opencode/minimax-m2.5-free",
-  "small_model": "opencode/minimax-m2.5-free",
+  "model": "opencode/nemotron-3-ultra-free",
+  "small_model": "opencode/nemotron-3-ultra-free",
   "disabled_providers": ["openai"],
   "plugin": [
     "openslimedit@1.0.4",

--- a/.github/builder/opencode-config.json
+++ b/.github/builder/opencode-config.json
@@ -14,7 +14,7 @@
   "share": "manual",
   "default_agent": "build",
   "model": "opencode/nemotron-3-ultra-free",
-  "small_model": "opencode/nemotron-3-ultra-free",
+  "small_model": "opencode/deepseek-v4-flash-free",
   "disabled_providers": ["openai"],
   "plugin": [
     "openslimedit@1.0.4",

--- a/.github/workflows/_run-agent.yml
+++ b/.github/workflows/_run-agent.yml
@@ -133,9 +133,12 @@ jobs:
       - name: Run OpenCode
         id: opencode
         if: inputs.provider == 'opencode'
-        # Only swallow the failure when a fallback model is configured, so a
-        # solo run still fails the job normally.
-        continue-on-error: ${{ inputs.fallback_model != '' }}
+        # Must be a literal: expressions here are re-evaluated inside the
+        # composite action, where workflow inputs are empty, so
+        # `inputs.fallback_model != ''` silently becomes false
+        # (actions/runner#2418). The gate step below restores job failure
+        # when neither attempt succeeds.
+        continue-on-error: true
         uses: anomalyco/opencode/github@github-v1.2.25
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -160,11 +163,12 @@ jobs:
           MORPH_TIMEOUT: "60000"
           MORPH_MODEL: morph-v3-fast
         with:
-          model: ${{ inputs.model != '' && inputs.model || 'opencode/minimax-m2.5-free' }}
+          model: ${{ inputs.model != '' && inputs.model || 'opencode/nemotron-3-ultra-free' }}
           prompt: ${{ inputs.prompt }}
           use_github_token: false
 
       - name: Run OpenCode (fallback model)
+        id: opencode-fallback
         if: inputs.provider == 'opencode' && inputs.fallback_model != '' && steps.opencode.outcome == 'failure'
         uses: anomalyco/opencode/github@github-v1.2.25
         env:
@@ -193,6 +197,16 @@ jobs:
           model: ${{ inputs.fallback_model }}
           prompt: ${{ inputs.prompt }}
           use_github_token: false
+
+      # Restores the failure swallowed by continue-on-error on the primary
+      # OpenCode step when no fallback ran or the fallback was skipped.
+      - name: Fail if no OpenCode attempt succeeded
+        if: inputs.provider == 'opencode' && steps.opencode.outcome != 'success' && steps.opencode-fallback.outcome != 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::error::OpenCode failed (primary: ${{ steps.opencode.outcome }}, fallback: ${{ steps.opencode-fallback.outcome }})"
+          exit 1
 
       - name: Get Kilo version
         if: inputs.provider == 'kilo'

--- a/.github/workflows/_update-pkgbuilds.yml
+++ b/.github/workflows/_update-pkgbuilds.yml
@@ -21,8 +21,8 @@ jobs:
     uses: ./.github/workflows/_run-agent.yml
     with:
       provider: opencode
-      model: "opencode/minimax-m3-free"
-      fallback_model: "opencode/nemotron-3-ultra-free"
+      model: "opencode/nemotron-3-ultra-free"
+      fallback_model: "opencode/deepseek-v4-flash-free"
       prompt: |
         Update version-controlled PKGBUILDs to their latest upstream versions and open one pull request.
         ${{ inputs.packages != '' && format('Only process these package directories: {0}', inputs.packages) || 'If no packages are provided, process every package key in nvchecker.toml.' }}

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "instructions": ["instructions.md", "AGENTS.md"],
   "model": "opencode/nemotron-3-ultra-free",
-  "small_model": "opencode/nemotron-3-ultra-free",
+  "small_model": "opencode/deepseek-v4-flash-free",
   "permission": {
     "*": "allow",
     "sudo *": "deny",

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "instructions": ["instructions.md", "AGENTS.md"],
-  "model": "opencode/minimax-m3-free",
-  "small_model": "opencode/minimax-m3-free",
+  "model": "opencode/nemotron-3-ultra-free",
+  "small_model": "opencode/nemotron-3-ultra-free",
   "permission": {
     "*": "allow",
     "sudo *": "deny",


### PR DESCRIPTION
## Summary

Updates OpenCode model configurations across the repository and improves the fallback model handling in the agent workflow to work around a GitHub Actions runner limitation where workflow inputs are not accessible inside composite actions.

## Key Changes

- **Model updates**: Switch primary OpenCode model from `minimax-m2.5-free` / `minimax-m3-free` to `nemotron-3-ultra-free` across all configurations (`.opencode/opencode.json`, `.github/builder/opencode-config.json`, `.github/workflows/_update-pkgbuilds.yml`)
- **Fallback model**: Update fallback in `_update-pkgbuilds.yml` from `nemotron-3-ultra-free` to `deepseek-v4-flash-free`
- **Workflow robustness**: Fix the `continue-on-error` behavior in `_run-agent.yml`:
  - Change from conditional `continue-on-error: ${{ inputs.fallback_model != '' }}` to unconditional `continue-on-error: true`
  - Add explicit "Fail if no OpenCode attempt succeeded" step that restores job failure when neither primary nor fallback attempts succeed
  - This works around actions/runner#2418 where expressions are re-evaluated inside composite actions with empty workflow inputs
- **Fallback step tracking**: Add `id: opencode-fallback` to the fallback OpenCode step for proper outcome tracking

## Implementation Details

The workflow now always allows the primary OpenCode step to continue on error, then uses a dedicated gate step to enforce failure when appropriate. This ensures:
- Job failure is restored when no fallback model is configured and the primary attempt fails
- Job failure is restored when a fallback is configured but both attempts fail
- The fallback step only runs when the primary fails and a fallback model is configured

https://claude.ai/code/session_01STarHFfDKqVTBG9bkEXzHb