### PR TITLE
🧹 [vp-dev] Replace generic exception handling with specific exceptions

### DIFF
--- a/vp-dev.py
+++ b/vp-dev.py
@@ -294,7 +294,7 @@ makepkg -si
             else:
                 warn(f"Failed to parse {d.name}/PKGBUILD")
                 return None
-        except (OSError, subprocess.SubprocessError) as e:
+        except (OSError, ValueError, subprocess.SubprocessError) as e:
             err(f"Error processing package {d}: {e}")
             return None
 

--- a/vp-dev.py
+++ b/vp-dev.py
@@ -252,7 +252,7 @@ makepkg -si
                     "url": data.get("url", ""),
                     "files": files,
                 }
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, ValueError, subprocess.SubprocessError):
             pass
         return None
 

--- a/vp-dev.py
+++ b/vp-dev.py
@@ -118,7 +118,7 @@ class VpDev:
                 "url": p[4] if len(p) > 4 else "",
                 "files": sorted(fs),
             }
-        except (OSError, subprocess.SubprocessError) as e:
+        except (OSError, ValueError, subprocess.SubprocessError) as e:
             err(f"Failed to parse {pb}: {e}")
             return None
 

--- a/vp-dev.py
+++ b/vp-dev.py
@@ -70,7 +70,7 @@ class VpDev:
                     if d not in self.files_cache:
                         self.files_cache[d] = []
                     self.files_cache[d].append(rel)
-        except Exception as e:
+        except (OSError, subprocess.SubprocessError) as e:
             warn(f"Failed to populate file cache: {e}")
             self.files_cache = None
 
@@ -118,7 +118,7 @@ class VpDev:
                 "url": p[4] if len(p) > 4 else "",
                 "files": sorted(fs),
             }
-        except Exception as e:
+        except (OSError, subprocess.SubprocessError) as e:
             err(f"Failed to parse {pb}: {e}")
             return None
 
@@ -252,7 +252,7 @@ makepkg -si
                     "url": data.get("url", ""),
                     "files": files,
                 }
-        except Exception:
+        except (OSError, subprocess.SubprocessError):
             pass
         return None
 
@@ -294,7 +294,7 @@ makepkg -si
             else:
                 warn(f"Failed to parse {d.name}/PKGBUILD")
                 return None
-        except Exception as e:
+        except (OSError, subprocess.SubprocessError) as e:
             err(f"Error processing package {d}: {e}")
             return None
 
@@ -314,7 +314,7 @@ makepkg -si
                 m = re.search(r'^VERSION="([^"]+)"', vp.read_text(), re.MULTILINE)
                 if m:
                     vv = m.group(1)
-            except Exception:
+            except OSError:
                 pass
 
         if self.pkg_json.exists():

--- a/vp-dev.py
+++ b/vp-dev.py
@@ -70,7 +70,7 @@ class VpDev:
                     if d not in self.files_cache:
                         self.files_cache[d] = []
                     self.files_cache[d].append(rel)
-        except (OSError, subprocess.SubprocessError) as e:
+        except (OSError, ValueError, subprocess.SubprocessError) as e:
             warn(f"Failed to populate file cache: {e}")
             self.files_cache = None
 

--- a/vp-dev.py
+++ b/vp-dev.py
@@ -314,7 +314,7 @@ makepkg -si
                 m = re.search(r'^VERSION="([^"]+)"', vp.read_text(), re.MULTILINE)
                 if m:
                     vv = m.group(1)
-            except OSError:
+            except (OSError, ValueError):
                 pass
 
         if self.pkg_json.exists():


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception:` handlers in `vp-dev.py` with specific exceptions, primarily `OSError` and `subprocess.SubprocessError`.
💡 **Why:** Catching `Exception` is too broad and can hide logical bugs. Using specific exceptions improves maintainability and ensures that only expected operational errors are suppressed.
✅ **Verification:** Verified that the script still passes syntax checks with `py_compile`. Checked the file content to ensure all targets were updated. Ran existing unit tests; confirmed that the single failure (`test_clean`) was pre-existing and unrelated to these changes.
✨ **Result:** Improved code health and reliability of the `vp-dev` tool.

---
*PR created automatically by Jules for task [10804496301003954967](https://jules.google.com/task/10804496301003954967) started by @Ven0m0*