### PR TITLE
🧹 [code health] Remove unused mock_open import from test_vp_dev.py

### DIFF
--- a/tests/test_vp_dev.py
+++ b/tests/test_vp_dev.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 import sys
 import os
 import importlib.util


### PR DESCRIPTION
🎯 What: Removed the unused `mock_open` function from the `unittest.mock` import in `tests/test_vp_dev.py`.
💡 Why: `mock_open` was identified by static analysis as unused in the file. Removing it cleans up the module namespace and improves code maintainability.
✅ Verification: Ran pytest and confirmed all 25 tests pass, verifying this removal caused no regressions.
✨ Result: A cleaner test file with no unused imports.

---
*PR created automatically by Jules for task [7089252231926124130](https://jules.google.com/task/7089252231926124130) started by @Ven0m0*